### PR TITLE
Removed ecmaVersion and sourceType Eslint parserOptions 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,8 +7,6 @@
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaVersion": 12,
-    "sourceType": "module",
     "project": ["tsconfig.json"]
   },
   "plugins": ["@typescript-eslint"],


### PR DESCRIPTION
they conflicted with tsconfig configuration leading to differences between your IDE and tsc output.

mea culpa.

### Description of changes proposed in this pull request:

- Removes parser options from eslint and has no effect on the sdk lib or contracts

### Checks:

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
